### PR TITLE
Add Floating Feedback Button and Customizable Page Titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ To use the `OpenFeedbackModal` component, you will need to add it to your `packa
 
 Clicking on it will open a dialog box for users to send feedback.
 
+In the sidebar
 ```typescript
 import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 
@@ -99,6 +100,19 @@ import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
   {/* Other SidebarItems */}
 </Sidebar>;
 ```
+
+Floating button
+```typescript
+import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
+
+// Anywhere
+<OpenFeedbackModal 
+  floating={true} 
+  style={{ position: 'fixed', bottom: 20, right: 20}}
+/>
+```
+
+
 
 ## Using the OpenFeedbackForm Component
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To use the `OpenFeedbackModal` component, you will need to add it to your `packa
 Clicking on it will open a dialog box for users to send feedback.
 
 In the sidebar
+
 ```typescript
 import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 
@@ -102,16 +103,16 @@ import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 ```
 
 Floating button
+
 ```typescript
 import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 
 // Anywhere
-<OpenFeedbackModal floating
-  style={{ position: 'fixed', bottom: 20, right: 20}}
-/>
+<OpenFeedbackModal
+  floating
+  style={{ position: 'fixed', bottom: 20, right: 20 }}
+/>;
 ```
-
-
 
 ## Using the OpenFeedbackForm Component
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ Floating button
 import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 
 // Anywhere
-<OpenFeedbackModal 
-  floating={true} 
+<OpenFeedbackModal floating
   style={{ position: 'fixed', bottom: 20, right: 20}}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 // Anywhere
 <OpenFeedbackModal
   floating
+  title="Super Feedback!" // Optional, defaults to "Feedback"
+  color="primary" // Optional, defaults to "primary"
+  icon={FeedbackIcon} // Optional, defaults to the feedback icon
   style={{ position: 'fixed', bottom: 20, right: 20, color: 'primary' }}
+  // Optional, defaults the Material-UI fab style
 />;
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ import { OpenFeedbackModal } from '@parsifal-m/backstage-plugin-open-feedback';
 // Anywhere
 <OpenFeedbackModal
   floating
-  style={{ position: 'fixed', bottom: 20, right: 20 }}
+  style={{ position: 'fixed', bottom: 20, right: 20, color: 'primary' }}
 />;
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ In the `OpenFeedbackPage` you will be able to see all the feedback that has been
 const routes = (
   <FlatRoutes>
     // Other routes
-    <Route path="/open-feedback" element={<OpenFeedbackPage />} />
+    <Route
+      path="/open-feedback"
+      element={
+        <OpenFeedbackPage
+          title="My Super Feedback Title!" // Optional
+          subtitle="A Super Subtitle!" // Optional
+        />
+      }
+    />
   </FlatRoutes>
 );
 ```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,5 +1,5 @@
 app:
-  title: Backstage
+  title: OpenFeedback
   baseUrl: http://localhost:3000
 
 organization:

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { Fab, makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ThumbUpAltIcon from '@material-ui/icons/ThumbUpAlt';
 import ExtensionIcon from '@material-ui/icons/Extension';
@@ -95,12 +95,10 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       </SidebarGroup>
     </Sidebar>
     {children}
-    <Fab
-      color="primary"
-      aria-label="open feedback"
-      style={{ position: 'fixed', bottom: 20, right: 20 }}
-    >
-      <OpenFeedbackModal icon={FeedbackIcon} />
-    </Fab>
+    <OpenFeedbackModal 
+      icon={FeedbackIcon} 
+      floating={true} 
+      style={{ position: 'fixed', bottom: 20, right: 20, color: 'white'}}
+    />
   </SidebarPage>
 );

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -95,9 +95,10 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       </SidebarGroup>
     </Sidebar>
     {children}
-    <OpenFeedbackModal floating
-      icon={FeedbackIcon} 
-      style={{ position: 'fixed', bottom: 20, right: 20, color: 'white'}}
+    <OpenFeedbackModal
+      floating
+      icon={FeedbackIcon}
+      style={{ position: 'fixed', bottom: 20, right: 20, color: 'white' }}
     />
   </SidebarPage>
 );

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,8 +1,9 @@
 import React, { PropsWithChildren } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { Fab, makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ThumbUpAltIcon from '@material-ui/icons/ThumbUpAlt';
 import ExtensionIcon from '@material-ui/icons/Extension';
+import FeedbackIcon from '@material-ui/icons/Feedback';
 import MapIcon from '@material-ui/icons/MyLocation';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
@@ -94,5 +95,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       </SidebarGroup>
     </Sidebar>
     {children}
+    <Fab
+      color="primary"
+      aria-label="open feedback"
+      style={{ position: 'fixed', bottom: 20, right: 20 }}
+    >
+      <OpenFeedbackModal icon={FeedbackIcon} />
+    </Fab>
   </SidebarPage>
 );

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -95,9 +95,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       </SidebarGroup>
     </Sidebar>
     {children}
-    <OpenFeedbackModal 
+    <OpenFeedbackModal floating
       icon={FeedbackIcon} 
-      floating={true} 
       style={{ position: 'fixed', bottom: 20, right: 20, color: 'white'}}
     />
   </SidebarPage>

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -98,7 +98,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
     <OpenFeedbackModal
       floating
       icon={FeedbackIcon}
-      style={{ position: 'fixed', bottom: 20, right: 20, color: 'white' }}
+      style={{ position: 'fixed', bottom: 20, right: 20, color: 'primary' }}
     />
   </SidebarPage>
 );

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -22,6 +22,7 @@ import {
   DialogActions,
   Fab,
 } from '@material-ui/core';
+import { cleanUrl } from '../../utils/cleanUrl';
 
 export type ButtonOpenfeedbackProps = {
   icon?: IconComponent;
@@ -34,7 +35,7 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
   const [comment, setComment] = useState('');
   const [anonymous, setAnonymous] = useState(false);
   const [open, setOpen] = useState(false);
-  const [url, setUrl] = useState(window.location.href);
+  const [url, setUrl] = useState(cleanUrl(window.location.href));
   const feedbackApi = useApi(openFeedbackBackendRef);
   const identity = useApi(identityApiRef);
   const Icon = props.icon ? props.icon : ThumbUpAltIcon;
@@ -74,7 +75,7 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
 
   useEffect(() => {
     if (open) {
-      setUrl(window.location.href);
+      setUrl(cleanUrl(window.location.href));
     }
   }, [open]);
 

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -86,7 +86,7 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
       {!floating ? (
         <SidebarItem
           icon={Icon}
-          text="OpenFeedback"
+          text={props.title ?? 'Feedback'}
           onClick={() => setOpen(true)}
         />
       ) : (

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -28,6 +28,8 @@ type ButtonOpenfeedbackProps = {
   icon?: IconComponent;
   floating?: boolean;
   style?: React.CSSProperties;
+  title?: string;
+  color?: 'primary' | 'secondary';
 };
 
 export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
@@ -89,13 +91,13 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
         />
       ) : (
         <Fab
-          color="primary"
+          color={props.color ?? 'primary'}
           variant="extended"
           onClick={() => setOpen(true)}
           style={props.style}
         >
           <Icon style={{ marginRight: 4 }} />
-          Feedback
+          {props.title ?? 'Feedback'}
         </Fab>
       )}
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -5,7 +5,7 @@ import ThumbUpAltIcon from '@material-ui/icons/ThumbUpAlt';
 import {
   useApi,
   identityApiRef,
-  IconComponent,
+  IconComponent
 } from '@backstage/core-plugin-api';
 import Rating from '@mui/material/Rating';
 import { openFeedbackBackendRef } from '../../api/types';
@@ -20,13 +20,16 @@ import {
   FormControlLabel,
   Checkbox,
   DialogActions,
+  Fab,
 } from '@material-ui/core';
 
-export type SidebarOpenfeedbackProps = {
+export type ButtonOpenfeedbackProps = {
   icon?: IconComponent;
+  floating?: boolean;
+  style?: React.CSSProperties;
 };
 
-export const OpenFeedbackModal = (props: SidebarOpenfeedbackProps) => {
+export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
   const [rating, setRating] = useState<number | null>(2);
   const [comment, setComment] = useState('');
   const [anonymous, setAnonymous] = useState(false);
@@ -35,7 +38,7 @@ export const OpenFeedbackModal = (props: SidebarOpenfeedbackProps) => {
   const feedbackApi = useApi(openFeedbackBackendRef);
   const identity = useApi(identityApiRef);
   const Icon = props.icon ? props.icon : ThumbUpAltIcon;
-
+  const Floating = props.floating ?? false;
   const [userName, fetchUserName] = useAsyncFn(async () => {
     return await (
       await identity.getProfileInfo()
@@ -77,11 +80,18 @@ export const OpenFeedbackModal = (props: SidebarOpenfeedbackProps) => {
 
   return (
     <>
-      <SidebarItem
-        icon={Icon}
-        text="OpenFeedback"
-        onClick={() => setOpen(true)}
-      />
+      {!Floating ? (
+        <SidebarItem
+          icon={Icon}
+          text="OpenFeedback"
+          onClick={() => setOpen(true)}
+        />
+      ) : (
+        <Fab color="primary" variant="extended" onClick={() => setOpen(true)} style={props.style}>
+          <Icon style={{ marginRight: 4 }} />
+            Feedback
+        </Fab>
+      )}      
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
         <DialogTitle>Submit Feedback</DialogTitle>
         <DialogContent>

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -5,7 +5,7 @@ import ThumbUpAltIcon from '@material-ui/icons/ThumbUpAlt';
 import {
   useApi,
   identityApiRef,
-  IconComponent
+  IconComponent,
 } from '@backstage/core-plugin-api';
 import Rating from '@mui/material/Rating';
 import { openFeedbackBackendRef } from '../../api/types';
@@ -87,11 +87,16 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
           onClick={() => setOpen(true)}
         />
       ) : (
-        <Fab color="primary" variant="extended" onClick={() => setOpen(true)} style={props.style}>
+        <Fab
+          color="primary"
+          variant="extended"
+          onClick={() => setOpen(true)}
+          style={props.style}
+        >
           <Icon style={{ marginRight: 4 }} />
-            Feedback
+          Feedback
         </Fab>
-      )}      
+      )}
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
         <DialogTitle>Submit Feedback</DialogTitle>
         <DialogContent>

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -24,7 +24,7 @@ import {
 } from '@material-ui/core';
 import { cleanUrl } from '../../utils/cleanUrl';
 
-export type ButtonOpenfeedbackProps = {
+type ButtonOpenfeedbackProps = {
   icon?: IconComponent;
   floating?: boolean;
   style?: React.CSSProperties;

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -144,10 +144,10 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
               />
             </Box>
             <DialogActions>
-              <Button onClick={handleClose} variant="contained" color="primary">
+              <Button onClick={handleClose} variant="outlined" color="primary">
                 Close
               </Button>
-              <Button type="submit" variant="outlined" color="primary">
+              <Button type="submit" variant="contained" color="primary">
                 Submit
               </Button>
             </DialogActions>

--- a/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackModal/OpenFeedbackModal.tsx
@@ -39,7 +39,7 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
   const feedbackApi = useApi(openFeedbackBackendRef);
   const identity = useApi(identityApiRef);
   const Icon = props.icon ? props.icon : ThumbUpAltIcon;
-  const Floating = props.floating ?? false;
+  const floating = props.floating ?? false;
   const [userName, fetchUserName] = useAsyncFn(async () => {
     return await (
       await identity.getProfileInfo()
@@ -81,7 +81,7 @@ export const OpenFeedbackModal = (props: ButtonOpenfeedbackProps) => {
 
   return (
     <>
-      {!Floating ? (
+      {!floating ? (
         <SidebarItem
           icon={Icon}
           text="OpenFeedback"

--- a/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.test.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.test.tsx
@@ -46,4 +46,22 @@ describe('OpenFeedbackPage', () => {
     });
     expect(await screen.findByText('Collected Feedback')).toBeInTheDocument();
   });
+
+  it('renders the page with custom title and subtitle', async () => {
+    (usePermission as jest.Mock).mockReturnValue({ allowed: true });
+    await act(async () => {
+      renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [alertApiRef, mockAlertApi],
+            [openFeedbackBackendRef, mockOpenFeedbackBackendApi],
+          ]}
+        >
+          <OpenFeedbackPage title="Custom Title" subtitle="Custom Subtitle" />
+        </TestApiProvider>,
+      );
+    });
+    expect(await screen.findByText('Custom Title')).toBeInTheDocument();
+    expect(await screen.findByText('Custom Subtitle')).toBeInTheDocument();
+  });
 });

--- a/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.tsx
@@ -3,7 +3,7 @@ import { Typography, Grid } from '@material-ui/core';
 import { InfoCard, Header, Page, Content } from '@backstage/core-components';
 import { FeedbackCards } from '../OpenFeedbackCard/OpenFeedbackCard';
 
-interface OpenFeedbackPageProps {
+export interface OpenFeedbackPageProps {
   title?: string;
   subtitle?: string;
 }

--- a/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.tsx
+++ b/plugins/open-feedback/src/components/OpenFeedbackPage/OpenFeedbackPage.tsx
@@ -3,18 +3,23 @@ import { Typography, Grid } from '@material-ui/core';
 import { InfoCard, Header, Page, Content } from '@backstage/core-components';
 import { FeedbackCards } from '../OpenFeedbackCard/OpenFeedbackCard';
 
-export const OpenFeedbackPage = () => (
+interface OpenFeedbackPageProps {
+  title?: string;
+  subtitle?: string;
+}
+
+export const OpenFeedbackPage = ({
+  title = 'Welcome to OpenFeedback!',
+  subtitle = 'Collected Feedback for your Backstage App!',
+}: OpenFeedbackPageProps) => (
   <Page themeId="tool">
-    <Header
-      title="Welcome to OpenFeedback!"
-      subtitle="Collected Feedback for your Backstage App!"
-    />
+    <Header title={title} subtitle={subtitle} />
     <Content>
       <Grid container spacing={3}>
         <Grid item xs={12}>
           <InfoCard title="Collected Feedback">
             <Typography variant="body1">
-              The feedback collected from your users will be displayed below.
+              The feedback collected from users will be displayed below.
             </Typography>
           </InfoCard>
         </Grid>

--- a/plugins/open-feedback/src/utils/cleanUrl.ts
+++ b/plugins/open-feedback/src/utils/cleanUrl.ts
@@ -1,0 +1,4 @@
+export const cleanUrl = (fullUrl: string) => {
+  const url = new URL(fullUrl);
+  return url.pathname + url.search + url.hash;
+};


### PR DESCRIPTION
## What type of PR is this?

Please check the category that applies:

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation Update

## Description

This pull request introduces two main enhancements to the OpenFeedback plugin:

1. **Floating Feedback Button:**  
   - Added the ability to render the feedback button as a floating action button (FAB) anywhere on the page. This is customizable using the `floating` prop and can be positioned with inline styles.
   - Updated `Root.tsx` to demonstrate the floating button implementation with a feedback icon.

2. **Customizable Page Titles and Subtitles:**  
   - Modified the `OpenFeedbackPage` component to allow passing custom titles and subtitles via props. This enables more flexibility when integrating the feedback page into different sections of the Backstage app.
   - Included unit tests to verify that the custom title and subtitle are correctly rendered.

## Related Issues

(No specific issues linked)


## Testing

- [x] I have included or updated unit tests for my changes.
- [x] I would like some help writing tests.
- [ ] These changes do not require tests.
